### PR TITLE
Fixed movement under check logic

### DIFF
--- a/dispatcher/Move.cpp
+++ b/dispatcher/Move.cpp
@@ -79,6 +79,9 @@ vector<Move> MoveGenerator::removeKingTargetingMoves(const vector<Move>& moves, 
 
 /*
 Removes any moves that would leave the king in check after the move is applied.
+
+If the king is already in check, next move needs to make the king no longer in check.
+Else if the king is not in check, it should not move to a position that would put the king in check.
 */
 std::vector<Move> MoveGenerator::removeMovesLeavingKingInCheck(
     Board* board, 
@@ -87,14 +90,10 @@ std::vector<Move> MoveGenerator::removeMovesLeavingKingInCheck(
 
     std::vector<Move> validMoves;
     for (const auto& move : moves) {
-        if (!isInCheck(*board, color)) { 
-            validMoves.push_back(move); 
-        } else {
-            Board copy = *board;
-            copy.applyMove(move);
-            if (!isInCheck(copy, color)) {
-                validMoves.push_back(move);
-            }
+        Board copy = *board;
+        copy.applyMove(move);
+        if (!isInCheck(copy, color)) {
+            validMoves.push_back(move);
         }
     }
     return validMoves;

--- a/dispatcher/test/test_bot.cpp
+++ b/dispatcher/test/test_bot.cpp
@@ -74,3 +74,33 @@ TEST_F(AITest, AgainstSelf) {
     }
     ASSERT_TRUE(moveGen->isGameOver(board));
 }
+
+/**
+ * Tests that the king does not put itself in check.
+ * This is set up from a custom position.
+ */
+TEST_F(AITest, NoMoveIntoCheck) {
+    // Set up black pieces
+    board->setPieceBin(Board::BLACK_PAWNS, 0b0000000011101111000100000000000000000000000000000000000000000000);
+    board->setPieceRF(Board::BLACK_ROOKS, 7, 0);
+    board->setPieceRF(Board::BLACK_ROOKS, 7, 7);
+    board->setPieceRF(Board::BLACK_BISHOPS, 7, 2);
+    board->setPieceRF(Board::BLACK_BISHOPS, 4, 2);
+    board->setPieceRF(Board::BLACK_KING, 7, 4);
+    board->setPieceRF(Board::BLACK_KNIGHTS, 5, 2);
+    board->setPieceRF(Board::BLACK_KNIGHTS, 7, 6);
+    board->setPieceRF(Board::BLACK_QUEEN, 1, 2);
+    
+    // Set up white pieces
+    board->setPieceBin(Board::WHITE_PAWNS, 0b00000000000000000000000001000100100000010011100000000000);
+    board->setPieceBin(Board::WHITE_ROOKS, 0b00000000000000000000000000000000000000000000000010000001);
+    board->setPieceBin(Board::WHITE_KNIGHTS, 0b00000000000000000000000000000000000000000000000001000010);
+    board->setPieceBin(Board::WHITE_BISHOPS, 0b00000000000000000000000000000000000000000000000000100100);
+    board->setPieceRF(Board::WHITE_KING, 0, 4);
+
+    // White to move
+    board->applyMove(ai->findBestMove(board, WHITE).first);
+
+    // Test that white is not in check
+    ASSERT_FALSE(moveGen->isInCheck(*board, WHITE));
+}


### PR DESCRIPTION
When the king is not under check, a move that puts the king into check should not be valid. This PR fixes that issue.